### PR TITLE
Add snaping functionality

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -23,6 +23,8 @@ class _ExampleScreenState extends State<ExampleScreen> {
     initialScrollOffset: 0.0,
   );
 
+  int _snappedTile = 0;
+
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
@@ -50,7 +52,7 @@ class _ExampleScreenState extends State<ExampleScreen> {
             tabs: <Widget>[
               Tab(text: 'First'),
               Tab(text: 'Second'),
-              Tab(text: 'Third'),
+              Tab(text: 'Snapping'),
             ],
           ),
         ),
@@ -58,7 +60,7 @@ class _ExampleScreenState extends State<ExampleScreen> {
           children: <Widget>[
             _buildTab(0),
             _buildTab(1),
-            _buildTab(2),
+            _buildSnapping(2),
           ],
         ),
       ),
@@ -84,5 +86,32 @@ class _ExampleScreenState extends State<ExampleScreen> {
       separatorBuilder: (BuildContext context, int index) => const Divider(height: 2.0),
       anchor: 0.5,
     );
+  }
+
+  Widget _buildSnapping(int tab){
+    return InfiniteListView.snapping(
+      key: PageStorageKey(tab),
+      controller: _infiniteController,
+      itemExtent: 80,
+      onSnap: (index) {
+        setState(() {
+          _snappedTile = index;
+        });
+      },
+      itemBuilder: (BuildContext context, int index) {
+        return Material(
+          child: InkWell(
+            onTap: () {},
+            child: ListTile(
+              tileColor: _snappedTile == index ? Colors.red : null,
+              title: Text('Tab $tab Item #$index'),
+              subtitle: Text('Subtitle $index'),
+              trailing: const Icon(Icons.chevron_right),
+            ),
+          ),
+        );
+      },
+      anchor: 0.5,
+    ); 
   }
 }


### PR DESCRIPTION
We needed this functionality in one of our apps, so I implemented it into this package. It's up to the maintainers to decide if this is suitable for their package, but I thought that I might as well open a pull request since I had to make this anyway.

To make the list snap, I created a new named constructor, `InfiniteListView.snapping`. The reason for creating a new constructor is that this feature does not work with separators, and itemExtent needs to be non-null. I could have asserted that itemExtent is not null when snap is true in the `InfiniteListView.builder` constructor, but I think that that approach is less clear an more prone to errors.

When `snap` is set to true in the constructor, the list will animate to the closest child in the scroll direction when the delta between the two latest scroll events is below `snapTreshold` and run the `onSnap` callback.

I have edited the example app to show this feature in action.